### PR TITLE
Externalize Fatture in Cloud OAuth credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,21 @@ s121-pulse-manager/
 
 | Chiave Opzione | Descrizione | Default | Fonte |
 |----------------|-------------|---------|-------|
+| `SPM_FIC_CLIENT_ID` / `spm_fic_client_id` | OAuth Client ID Fatture in Cloud | - | [includes/oauth-utils.php:12] |
+| `SPM_FIC_CLIENT_SECRET` / `spm_fic_client_secret` | OAuth Client Secret Fatture in Cloud | - | [includes/oauth-utils.php:13] |
 | `spm_fic_access_token` | Token OAuth accesso Fatture in Cloud | - | [oauth.php:44] |
 | `spm_fic_refresh_token` | Token refresh OAuth per auto-rinnovo | - | [oauth.php:45] |
 | `spm_fic_company_id` | ID azienda target in Fatture in Cloud | - | [oauth.php:51] |
 | `spm_last_sync_timestamp` | Timestamp ultima sincronizzazione clienti | - | [api/fatture-in-cloud.php:162] |
 | `spm_last_sync_method` | Trigger sincronizzazione (manuale/cron) | - | [api/fatture-in-cloud.php:163] |
+
+Per sicurezza, definire `SPM_FIC_CLIENT_ID` e `SPM_FIC_CLIENT_SECRET` nel file `wp-config.php` o salvarli come opzioni protette `spm_fic_client_id` e `spm_fic_client_secret`. **Non** includere queste credenziali nel repository.
+
+```php
+// wp-config.php
+define('SPM_FIC_CLIENT_ID', 'your-client-id');
+define('SPM_FIC_CLIENT_SECRET', 'your-client-secret');
+```
 
 ### Configurazione Servizi [acf-fields/acf-servizi.php:1-180]
 

--- a/includes/oauth-utils.php
+++ b/includes/oauth-utils.php
@@ -6,10 +6,16 @@ use FattureInCloud\Configuration;
 use GuzzleHttp\Client;
 
 function get_valid_token() {
-	$access_token  = get_option('spm_fic_access_token');
-	$refresh_token = get_option('spm_fic_refresh_token');
-	$client_id     = "APSzK7BJjV5PsKWnrHwKeV3eSU91isoh";
-	$client_secret = "5Xd9ABBPXl1577NsSqyQlDmDrVgcqSRsv9Y85h1yWSSdWwUZAdy6kTcPlpuigU2q";
+        $access_token  = get_option('spm_fic_access_token');
+        $refresh_token = get_option('spm_fic_refresh_token');
+        // Credenziali definite in wp-config.php o salvate come opzioni protette.
+        $client_id     = defined('SPM_FIC_CLIENT_ID') ? SPM_FIC_CLIENT_ID : get_option('spm_fic_client_id');
+        $client_secret = defined('SPM_FIC_CLIENT_SECRET') ? SPM_FIC_CLIENT_SECRET : get_option('spm_fic_client_secret');
+
+        if (!$client_id || !$client_secret) {
+                error_log('[S121 OAuth] ❌ Client ID/Secret non configurati.');
+                return false;
+        }
 
 	$config = Configuration::getDefaultConfiguration()->setAccessToken($access_token);
 	$testApi = new UserApi(new Client(), $config);


### PR DESCRIPTION
## Summary
- load OAuth client id/secret from wp-config constants or protected options
- document how to define credentials outside of version control

## Testing
- `php -l includes/oauth-utils.php`
- `composer validate --no-check-all` *(fails: property name is required)*

------
https://chatgpt.com/codex/tasks/task_b_68a6e439ed648332b8f3d664baba306e